### PR TITLE
Adding date calls before and after displaying failing tests

### DIFF
--- a/metal-ipi-releases.sh
+++ b/metal-ipi-releases.sh
@@ -37,6 +37,7 @@ function fetchReleasesConfig() {
 }
 
 function checkForRefresh() {
+    echo "metal-ipi-releases.sh starting on $(date) ($(date --utc))"
     # Download the current Prow status
     if [ "$1" = "-c" ]; then 
         ver=$2
@@ -124,3 +125,4 @@ printf "$fmt" "VER" "TYPE" "JOB" "STARTED" "FAILURE REASON" "LINKS"
 showResultsFor "$metalInforming" "Informing"
 showResultsFor "$metalUpgrades" "Upgrade"
 showResultsFor "$metalBlocking" "Blocking"
+echo "metal-ipi-releases.sh finished on $(date) ($(date --utc))"


### PR DESCRIPTION
Having date information in terminal scrollback may be very useful
for the person on metal-support duty - it can be used to correlate
historical data from the script with log messages etc while
troubleshooting. Both local time and Zulu/UTC are displayed.